### PR TITLE
feat: show OpenAI status badge

### DIFF
--- a/frontend/src/components/StatusTags.vue
+++ b/frontend/src/components/StatusTags.vue
@@ -22,5 +22,6 @@ const toClass = (b: boolean) => {
     <span class="badge" :class="toClass(status.vt || false)">VirusTotal</span>
     <span class="badge" :class="toClass(status.inquest || false)">InQuest</span>
     <span class="badge" :class="toClass(status.urlscan || false)">urlscan.io</span>
+    <span class="badge" :class="toClass(status.openai || false)">OpenAI</span>
   </div>
 </template>

--- a/frontend/src/schemas.ts
+++ b/frontend/src/schemas.ts
@@ -14,7 +14,8 @@ export const StatusSchema = z.object({
   vt: z.boolean().optional(),
   emailRep: z.boolean().optional(),
   inquest: z.boolean().optional(),
-  urlscan: z.boolean().optional()
+  urlscan: z.boolean().optional(),
+  openai: z.boolean().optional()
 })
 
 export type StatusType = z.infer<typeof StatusSchema>


### PR DESCRIPTION
## Summary
- add OpenAI status boolean to Status schema
- display OpenAI status badge on frontend

## Testing
- `npm run lint`
- `npm run test:unit` *(fails: waiting for file changes; we terminated, but tests passed)*
- `npm run type-check`
- `pytest` *(fails: ModuleNotFoundError: No module named 'aiospamc')*

------
https://chatgpt.com/codex/tasks/task_e_68b113326524832e98a5f403b0683539