### PR TITLE
feat: expose OpenAI verdict and debug logging

### DIFF
--- a/backend/clients/openai.py
+++ b/backend/clients/openai.py
@@ -22,12 +22,16 @@ class Openai:
 
     async def send_prompt(self, prompt: str, model: str = "gpt-3.5-turbo") -> str:
         """Send a prompt to ChatGPT asynchronously and return the reply."""
+        logger.debug("Sending prompt to OpenAI with model `{}`", model)
+        logger.debug("Prompt content: {}", prompt)
         completion = await asyncio.to_thread(
             self.client.chat.completions.create,
             model=model,
             messages=[{"role": "user", "content": prompt}],
         )
-        return completion.choices[0].message.content.strip()
+        response = completion.choices[0].message.content.strip()
+        logger.debug("Received response from OpenAI: {}", response)
+        return response
 
     async def __aenter__(self) -> "Openai":
         # No persistent connection to manage, but we keep the pattern

--- a/backend/factories/openai.py
+++ b/backend/factories/openai.py
@@ -1,3 +1,4 @@
+from loguru import logger
 from returns.functions import raise_exception
 from returns.future import FutureResultE, future_safe
 from returns.pipeline import flow
@@ -12,12 +13,14 @@ async def send_prompt(
     *, client: clients.Openai, prompt: str, model: str | None = None
 ) -> str:
     """Send a prompt to the OpenAI API using the wrapped Openai client."""
+    logger.debug("Sending prompt through OpenAIVerdictFactory")
     return await client.send_prompt(prompt, model=model or "gpt-3.5-turbo")
 
 
 @future_safe
 async def transform_response(response: str, *, name: str) -> schemas.Verdict:
     """Convert the raw OpenAI string response into a Verdict schema."""
+    logger.debug("Transforming OpenAI response into Verdict")
     return schemas.Verdict(
         name=name,
         malicious=False,  # Adjust if you plan to mark based on AI output
@@ -43,9 +46,12 @@ class OpenAIVerdictFactory:
         model: str | None = None,
     ) -> schemas.Verdict:
         """Orchestrate sending the prompt and converting the result to a Verdict."""
+        logger.debug("OpenAIVerdictFactory.call started")
         f_result: FutureResultE[schemas.Verdict] = flow(
             send_prompt(client=self.client, prompt=prompt, model=model),
             bind(lambda response: transform_response(response, name=self.name)),
         )
         result = await f_result.awaitable()
-        return unsafe_perform_io(result.alt(raise_exception).unwrap())
+        verdict = unsafe_perform_io(result.alt(raise_exception).unwrap())
+        logger.debug("OpenAIVerdictFactory.call completed")
+        return verdict

--- a/backend/factories/response.py
+++ b/backend/factories/response.py
@@ -16,10 +16,11 @@ from .emailrep import EmailRepVerdictFactory
 from .eml import EmlFactory
 from .inquest import InQuestVerdictFactory
 from .oldid import OleIDVerdictFactory
+from .openai import OpenAIVerdictFactory
 from .spamassassin import SpamAssassinVerdictFactory
 from .urlscan import UrlScanVerdictFactory
 from .virustotal import VirusTotalVerdictFactory
-from .openai import OpenAIVerdictFactory
+
 
 def log_exception(exception: Exception):
     logger.exception(exception)
@@ -69,12 +70,16 @@ async def get_vt_verdict(
 ) -> schemas.Verdict:
     return await VirusTotalVerdictFactory(client).call(sha256s)
 
-#start of added code
+
+# start of added code
 @future_safe
 async def get_openai_verdict(*, client: clients.Openai) -> schemas.Verdict:
     # This calls the new OpenAIVerdictFactory (like VirusTotalVerdictFactory etc.)
+    logger.debug("Requesting OpenAI verdict")
     return await OpenAIVerdictFactory(client).call()
-#end of added code
+
+
+# end of added code
 
 
 @future_safe
@@ -87,9 +92,9 @@ async def set_verdicts(
     optional_vt: clients.VirusTotal | None = None,
     optional_urlscan: clients.UrlScan | None = None,
     optional_inquest: clients.InQuest | None = None,
-    #start of added code
+    # start of added code
     optional_openai: clients.Openai | None = None,
-    #end of added code
+    # end of added code
 ) -> schemas.Response:
     f_results: list[FutureResultE[schemas.Verdict]] = [
         get_spam_assassin_verdict(eml_file, client=spam_assassin),
@@ -107,10 +112,11 @@ async def set_verdicts(
     if optional_inquest is not None:
         f_results.append(get_inquest_verdict(response.sha256s, client=optional_inquest))
 
-    #start of added code
+    # start of added code
     if optional_openai is not None:
+        logger.debug("Adding OpenAI verdict to result set")
         f_results.append(get_openai_verdict(client=optional_openai))
-    #end of added code
+    # end of added code
 
     if optional_urlscan is not None:
         f_results.append(get_urlscan_verdict(response.urls, client=optional_urlscan))
@@ -121,6 +127,7 @@ async def set_verdicts(
         for result in results
     ]
     response.verdicts = [value for value in values if value is not None]
+    logger.debug("Verdicts ready: {}", [v.name for v in response.verdicts])
     return response
 
 
@@ -135,9 +142,9 @@ class ResponseFactory(AbstractAsyncFactory):
         optional_vt: clients.VirusTotal | None = None,
         optional_urlscan: clients.UrlScan | None = None,
         optional_inquest: clients.InQuest | None = None,
-        #start of added code
+        # start of added code
         optional_openai: clients.Openai | None = None,
-        #end of added code
+        # end of added code
     ) -> schemas.Response:
         f_result: FutureResultE[schemas.Response] = flow(
             parse(eml_file),
@@ -150,9 +157,9 @@ class ResponseFactory(AbstractAsyncFactory):
                     optional_vt=optional_vt,
                     optional_urlscan=optional_urlscan,
                     optional_inquest=optional_inquest,
-                    #start of added code
+                    # start of added code
                     optional_openai=optional_openai,
-                    #end of added code
+                    # end of added code
                 )
             ),
         )

--- a/frontend/src/components/verdicts/VerdictItem.vue
+++ b/frontend/src/components/verdicts/VerdictItem.vue
@@ -10,6 +10,7 @@ const props = defineProps({
     required: true
   }
 })
+console.debug('Rendering verdict item', props.verdict)
 
 const title = computed(() => {
   return `${props.verdict.name}`

--- a/frontend/src/components/verdicts/VerdictsItem.vue
+++ b/frontend/src/components/verdicts/VerdictsItem.vue
@@ -4,12 +4,13 @@ import { type PropType } from 'vue'
 import Verdict from '@/components/verdicts/VerdictItem.vue'
 import type { VerdictType } from '@/schemas'
 
-defineProps({
+const props = defineProps({
   verdicts: {
     type: Array as PropType<VerdictType[]>,
     required: true
   }
 })
+console.debug('Received verdicts in component', props.verdicts)
 </script>
 
 <template>


### PR DESCRIPTION
## Summary
- log OpenAI prompt/response flow in backend
- surface and debug verdict rendering in the frontend

## Testing
- `ruff check --fix backend/clients/openai.py backend/factories/openai.py backend/factories/response.py`
- `ruff format backend/clients/openai.py backend/factories/openai.py backend/factories/response.py`
- `npm --prefix frontend run type-check`
- `npx eslint --fix src/components/verdicts/VerdictItem.vue src/components/verdicts/VerdictsItem.vue`
- `npx prettier --write src/components/verdicts/VerdictItem.vue src/components/verdicts/VerdictsItem.vue`
- `npx lefthook run pre-commit --files backend/clients/openai.py backend/factories/openai.py backend/factories/response.py frontend/src/components/verdicts/VerdictItem.vue frontend/src/components/verdicts/VerdictsItem.vue` *(fail: 403 Forbidden)*
- `uv run pytest` *(fail: Failed to download `ruff==0.12.3`)*

------
https://chatgpt.com/codex/tasks/task_e_68b6411f3560832e84499932ee50707e