### PR TITLE
feat: update openai client to v1.102

### DIFF
--- a/backend/clients/openai.py
+++ b/backend/clients/openai.py
@@ -1,12 +1,10 @@
-import asyncio
-
 from loguru import logger
-from openai import OpenAI
+from openai import AsyncOpenAI
 from starlette.datastructures import Secret
 
 
 class Openai:
-    """Async-compatible client wrapper for the OpenAI ChatGPT API."""
+    """Async client wrapper for the OpenAI Responses API."""
 
     def __init__(self, api_key: Secret):
         key = (
@@ -18,18 +16,17 @@ class Openai:
             logger.debug("OpenAI API key is missing or empty.")
             raise ValueError("OpenAI API key is missing.")
         logger.debug("OpenAI API key loaded successfully.")
-        self.client = OpenAI(api_key=key)
+        self.client = AsyncOpenAI(api_key=key)
 
     async def send_prompt(self, prompt: str, model: str = "gpt-5o") -> str:
-        """Send a prompt to ChatGPT asynchronously and return the reply."""
+        """Send a prompt to OpenAI asynchronously and return the reply."""
         logger.debug("Sending prompt to OpenAI with model `{}`", model)
         logger.debug("Prompt content: {}", prompt)
-        completion = await asyncio.to_thread(
-            self.client.chat.completions.create,
+        completion = await self.client.responses.create(
             model=model,
-            messages=[{"role": "user", "content": prompt}],
+            input=prompt,
         )
-        response = completion.choices[0].message.content.strip()
+        response = completion.output_text.strip()
         logger.debug("Received response from OpenAI: {}", response)
         return response
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
   "ioc-finder>=7.3.0,<8.0.0",
   "loguru>=0.7.3",
   "oletools==0.60.2",
-  "openai>=1.99.9",
+  "openai>=1.102.0",
   "pydantic>=2.11.7",
   "pyhumps>=3.8,<4.0",
   "python-dotenv>=1.1.1",


### PR DESCRIPTION
## Summary
- migrate OpenAI client to latest Responses API
- bump OpenAI dependency to 1.102.0

## Testing
- `uv lock` *(fails: Failed to fetch: `https://pypi.org/simple/openai/`)*
- `uv run ruff check` *(fails: Failed to fetch: `https://pypi.org/simple/aiofiles/`)*
- `uv run pytest` *(fails: Failed to fetch: `https://pypi.org/simple/gunicorn/`)*

------
https://chatgpt.com/codex/tasks/task_e_68b738023cb8832eb173b38847169bac