### PR TITLE
Make OpenAI model configurable with gpt-4o default

### DIFF
--- a/backend/clients/openai.py
+++ b/backend/clients/openai.py
@@ -2,6 +2,8 @@ from loguru import logger
 from openai import AsyncOpenAI
 from starlette.datastructures import Secret
 
+from backend import settings
+
 
 class Openai:
     """Async client wrapper for the OpenAI Responses API."""
@@ -18,8 +20,9 @@ class Openai:
         logger.debug("OpenAI API key loaded successfully.")
         self.client = AsyncOpenAI(api_key=key)
 
-    async def send_prompt(self, prompt: str, model: str = "gpt-5o") -> str:
+    async def send_prompt(self, prompt: str, model: str | None = None) -> str:
         """Send a prompt to OpenAI asynchronously and return the reply."""
+        model = model or settings.OPENAI_MODEL
         logger.debug("Sending prompt to OpenAI with model `{}`", model)
         logger.debug("Prompt content: {}", prompt)
         completion = await self.client.responses.create(

--- a/backend/settings.py
+++ b/backend/settings.py
@@ -41,6 +41,7 @@ EMAIL_REP_API_KEY: Secret | None = config(
 )
 #start of added code
 OPENAI_API_KEY: Secret | None = config("OPENAI_API_KEY", cast=Secret, default=None)
+OPENAI_MODEL: str = config("OPENAI_MODEL", cast=str, default="gpt-4o")
 #COPILOT_API_KEY: Secret | None = config("COPILOT_API_KEY", cast=Secret, default=None)
 #ANYRUN_API_KEY: Secret | None = config("ANYRUN_API_KEY", cast=Secret, default=None)
 #end of added code


### PR DESCRIPTION
## Summary
- make OpenAI model configurable via `OPENAI_MODEL` setting
- default `send_prompt` to use configured model

## Testing
- `curl https://api.openai.com/v1/models` *(fails: CONNECT tunnel failed, response 403)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'aiospamc')*

------
https://chatgpt.com/codex/tasks/task_e_68b75b817088832e8f4614bd963f2acf