### PR TITLE
Improve OpenAI logging and error handling

### DIFF
--- a/backend/clients/openai_client.py
+++ b/backend/clients/openai_client.py
@@ -1,5 +1,3 @@
-import asyncio
-
 from loguru import logger
 from openai import OpenAI
 from starlette.datastructures import Secret
@@ -37,7 +35,9 @@ class Openai:
             "OpenAI client: received response (len={})",
             len(text),
         )
-        return (response.output_text)
+        truncated = text[:200] + ("..." if len(text) > 200 else "")
+        logger.debug("OpenAI client: response text: {}", truncated)
+        return response.output_text
 
     async def __aenter__(self) -> "Openai":
         # No persistent connection to manage, but we keep the pattern


### PR DESCRIPTION
## Summary
- Log truncated OpenAI response text in factories and client
- Add error handling around client call with partial-response logging

## Testing
- `ruff check backend/factories/openai.py backend/clients/openai_client.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'aiospamc')*


------
https://chatgpt.com/codex/tasks/task_e_68b83dea4ba0832e918511feceac5587