### PR TITLE
refactor: make openai client synchronous and reduce prompts

### DIFF
--- a/backend/api/endpoints/submit.py
+++ b/backend/api/endpoints/submit.py
@@ -1,3 +1,4 @@
+import asyncio
 import httpx
 from fastapi import APIRouter, HTTPException, status
 
@@ -94,10 +95,9 @@ async def send_to_chatgpt(
         )
 
     try:
-        full_prompt = (
-            f"{prompt.prompt}\nHeader: {header.header!s}\nBody: {body.content}"
-        )
-        reply = await optional_openai.send_prompt(
+        full_prompt = f"{prompt.prompt}\nBody: {body.content}"
+        reply = await asyncio.to_thread(
+            optional_openai.send_prompt,
             prompt=full_prompt,
             model=prompt.model,
         )

--- a/backend/clients/openai_client.py
+++ b/backend/clients/openai_client.py
@@ -1,12 +1,12 @@
 from loguru import logger
 import httpx
 import openai
-from openai import AsyncOpenAI
+from openai import OpenAI
 from starlette.datastructures import Secret
 
 
 class Openai:
-    """Async-compatible wrapper around the OpenAI Responses API."""
+    """Synchronous wrapper around the OpenAI Responses API."""
 
     def __init__(self, api_key: Secret):
         key = (
@@ -18,17 +18,17 @@ class Openai:
             logger.debug("OpenAI API key is missing or empty.")
             raise ValueError("OpenAI API key is missing.")
         logger.debug("OpenAI API key loaded successfully.")
-        self.client = AsyncOpenAI(api_key=key)
+        self.client = OpenAI(api_key=key)
 
-    async def send_prompt(self, prompt: str, model: str = "gpt-4o-mini") -> str:
-        """Send a prompt asynchronously and return the text response."""
+    def send_prompt(self, prompt: str, model: str = "gpt-4o-mini") -> str:
+        """Send a prompt and return the text response."""
         logger.debug(
             "OpenAI client: dispatching prompt (len={}, model={})",
             len(prompt),
             model,
         )
         try:
-            response = await self.client.responses.create(
+            response = self.client.responses.create(
                 model=model,
                 input=prompt,
                 store=True,
@@ -48,10 +48,10 @@ class Openai:
 
         return response.output_text
 
-    async def __aenter__(self) -> "Openai":
+    def __enter__(self) -> "Openai":
         # No persistent connection to manage, but we keep the pattern
         return self
 
-    async def __aexit__(self, exc_type, exc, tb) -> None:
+    def __exit__(self, exc_type, exc, tb) -> None:
         # No cleanup needed for the OpenAI SDK
         pass

--- a/backend/dependencies.py
+++ b/backend/dependencies.py
@@ -53,19 +53,19 @@ async def _get_optional_inquest(api_key: Secret | None = settings.INQUEST_API_KE
 
 
 # Start of added code
-@asynccontextmanager
-async def _get_optional_openai(api_key: Secret | None = settings.OPENAI_API_KEY):
+@contextmanager
+def _get_optional_openai(api_key: Secret | None = settings.OPENAI_API_KEY):
     if api_key is None:
         logger.debug("OpenAI API key not provided.")
         yield None
     else:
         logger.debug("OpenAI API key loaded.")
-        async with clients.Openai(api_key=api_key) as client:
+        with clients.Openai(api_key=api_key) as client:
             yield client
 
 
-async def get_optional_openai():
-    async with _get_optional_openai(settings.OPENAI_API_KEY) as client:
+def get_optional_openai():
+    with _get_optional_openai(settings.OPENAI_API_KEY) as client:
         yield client
 
 


### PR DESCRIPTION
## Summary
- remove async OpenAI client usage and switch to synchronous implementation
- shrink prompts to include only message bodies
- adjust OpenAI dependencies and chat endpoint for new client

## Testing
- `ruff check backend/clients/openai_client.py backend/dependencies.py backend/factories/openai.py backend/api/endpoints/submit.py`
- `pytest` *(failed: No module named 'aiospamc')*
- `pip install aiospamc` *(failed: Could not find a version that satisfies the requirement aiospamc (from versions: none))*

------
https://chatgpt.com/codex/tasks/task_e_68b84a6170a8832e93e163d38d9c029b