### PR TITLE
Ensure OpenAI verdict uses backend response

### DIFF
--- a/backend/clients/openai_client.py
+++ b/backend/clients/openai_client.py
@@ -1,6 +1,6 @@
-from loguru import logger
 import httpx
 import openai
+from loguru import logger
 from openai import OpenAI
 from starlette.datastructures import Secret
 
@@ -46,7 +46,8 @@ class Openai:
         truncated = text[:200] + ("..." if len(text) > 200 else "")
         logger.debug("OpenAI client: response text: {}", truncated)
 
-        return response.output_text
+        # Always return the processed text to avoid propagating ``None`` values
+        return text
 
     def __enter__(self) -> "Openai":
         # No persistent connection to manage, but we keep the pattern

--- a/backend/factories/openai.py
+++ b/backend/factories/openai.py
@@ -1,4 +1,5 @@
 import asyncio
+
 from loguru import logger
 from returns.functions import raise_exception
 from returns.future import FutureResultE, future_safe
@@ -42,7 +43,8 @@ async def send_prompt(
     if response_text and len(response_text) > 200:
         truncated += "..."
     logger.debug("OpenAI send_prompt: received response: {}", truncated)
-    return response_text
+    # Ensure a string is always returned for downstream processing
+    return response_text or ""
 
 
 @future_safe

--- a/tests/factories/test_openai.py
+++ b/tests/factories/test_openai.py
@@ -1,0 +1,23 @@
+import pytest
+
+from backend import factories
+
+
+class DummyOpenAIClient:
+    def send_prompt(self, prompt: str, model: str = "gpt-4o-mini") -> str:
+        return "dummy response"
+
+
+@pytest.fixture
+def factory() -> factories.OpenAIVerdictFactory:
+    client = DummyOpenAIClient()
+    return factories.OpenAIVerdictFactory(client)
+
+
+@pytest.mark.asyncio
+async def test_openai_factory(
+    sample_eml: bytes, factory: factories.OpenAIVerdictFactory
+):
+    eml = factories.EmlFactory().call(sample_eml)
+    verdict = await factory.call(eml)
+    assert verdict.details[0].description == "dummy response"


### PR DESCRIPTION
## Summary
- return sanitized text from OpenAI client to avoid None values
- always provide a string from OpenAI verdict factory
- add test verifying OpenAI verdict carries backend response

## Testing
- `npm run test:unit`
- `pytest tests/factories/test_openai.py` *(fails: No module named 'aiospamc')*

------
https://chatgpt.com/codex/tasks/task_e_68b8552bda40832eb034a6f9d3b7a969