### PR TITLE
feat: add OpenAI haiku output to analysis

### DIFF
--- a/backend/schemas/eml.py
+++ b/backend/schemas/eml.py
@@ -32,6 +32,7 @@ class Body(APIModel):
     emails: list[str]
     domains: list[str]
     ip_addresses: list[str]
+    ai_text: str | None = None
 
 
 class Received(APIModel):

--- a/frontend/src/components/bodies/BodyItem.vue
+++ b/frontend/src/components/bodies/BodyItem.vue
@@ -45,6 +45,10 @@ defineProps({
           </div>
         </td>
       </tr>
+      <tr v-if="body.aiText">
+        <th class="w-80">AI text</th>
+        <td>{{ body.aiText }}</td>
+      </tr>
       <tr v-if="body.ipAddresses.length > 0">
         <th class="w-80">Extracted IPv4s</th>
         <td>

--- a/frontend/src/schemas.ts
+++ b/frontend/src/schemas.ts
@@ -56,7 +56,8 @@ export const BodySchema = z.object({
   urls: z.array(z.string()),
   emails: z.array(z.string()),
   domains: z.array(z.string()),
-  ipAddresses: z.array(z.string())
+  ipAddresses: z.array(z.string()),
+  aiText: z.string().nullish()
 })
 
 export type BodyType = z.infer<typeof BodySchema>


### PR DESCRIPTION
## Summary
- call OpenAI with debug logging at end of EML analysis and attach response to bodies
- expose new `aiText` field in API and display on frontend below extracted domains

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'aiospamc')*
- `npm run test:unit`


------
https://chatgpt.com/codex/tasks/task_e_68b8f7623160832ebe54af65fb0a7462