### PR TITLE
feat: expose plaintext body from analyzed eml

### DIFF
--- a/tests/api/endpoints/test_analyze.py
+++ b/tests/api/endpoints/test_analyze.py
@@ -30,3 +30,10 @@ def test_analyze_file_with_invalid_file(client: TestClient):
     data = {"file": b""}
     response = client.post("/api/analyze/file", files=data)
     assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
+
+def test_analyze_plaintext_body(client: TestClient, sample_eml: bytes):
+    payload = {"file": sample_eml.decode()}
+    response = client.post("/api/analyze/body", json=payload)
+    json = response.json()
+    assert "Lorem ipsum dolor sit amet" in json.get("body", "")


### PR DESCRIPTION
## Summary
- add helper to pull plaintext segments from parsed EML
- provide `/body` endpoint returning the plaintext body of an EML
- test extraction of plaintext body

## Testing
- `pytest tests/api/endpoints/test_analyze.py::test_analyze_plaintext_body -q` *(fails: ModuleNotFoundError: No module named 'aiospamc')*

------
https://chatgpt.com/codex/tasks/task_e_68b9381056a8832ead1ad072b97aaa3f