### PR TITLE
Capture plaintext body during analysis

### DIFF
--- a/backend/api/endpoints/analyze.py
+++ b/backend/api/endpoints/analyze.py
@@ -106,6 +106,10 @@ async def analyze(
         optional_vt=optional_vt,
     )
 
+    plaintext_body = get_plaintext_body(response.eml)
+    if settings.DEBUG:
+        logger.debug("Plaintext body length: {}", len(plaintext_body))
+
     if optional_redis is not None:
         background_tasks.add_task(
             cache_response, redis=optional_redis, response=response


### PR DESCRIPTION
## Summary
- capture the plaintext body within the analyze endpoint
- log the plaintext body length when debugging

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'aiospamc')*
- `pip install '.[dev]'` *(fails: Could not connect to proxy, 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b93e9f375c832eb6d4f1ca9fa74553